### PR TITLE
MIGENG-152 Some enhancements

### DIFF
--- a/src/main/resources/spring/camel-context.xml
+++ b/src/main/resources/spring/camel-context.xml
@@ -31,10 +31,6 @@
 
     <camelContext id="camel" xmlns="http://camel.apache.org/schema/spring">
 
-        <dataFormats>
-            <bindy id="workloadInventoryReportModelBindyDataformat" type="Csv" classType="org.jboss.xavier.analytics.pojo.output.workload.inventory.WorkloadInventoryReportModel"/>
-        </dataFormats>
-
         <restConfiguration apiContextPath="/api-doc" apiContextRouteId="doc-api" component="servlet" bindingMode="json">
             <endpointProperty key="headerFilterStrategy" value="#restResponseHeaderRemover"/>
             <apiProperty key="api.title" value="Migration Analytics REST API"/>
@@ -109,16 +105,13 @@
                     <bean ref="workloadInventoryReportService" method="findByAnalysisId(${header.id}, ${header.pageBean}, ${header.sortBean})" />
                 </route>
             </get>
-            <get uri="/{id}/workload-inventory/csv">
+            <get uri="/{id}/workload-inventory/csv" produces="text/csv">
                 <description>Get the Workload Inventory Reports in CSV format</description>
                 <route id="workload-inventory-report-get-details-as-csv">
                     <bean ref="workloadInventoryReportService" method="findByAnalysisId(${header.id})" />
                     <to uri="direct:toWorkloadInventoryReportCsv" />
                     <setHeader headerName="Content-Disposition">
-                        <simple>attachment;filename=workloadInventory.csv</simple>
-                    </setHeader>
-                    <setHeader headerName="Content-Type">
-                        <constant>text/csv</constant>
+                        <simple>attachment;filename=workloadInventory_${header.id}.csv</simple>
                     </setHeader>
                 </route>
             </get>
@@ -136,7 +129,9 @@
 
         <route id="workload-inventory-report-model-to-csv">
             <from uri="direct:toWorkloadInventoryReportCsv" />
-            <marshal ref="workloadInventoryReportModelBindyDataformat" />
+            <marshal>
+                <bindy id="workloadInventoryReportModelBindyDataformat" type="Csv" classType="org.jboss.xavier.analytics.pojo.output.workload.inventory.WorkloadInventoryReportModel"/>
+            </marshal>
         </route>
 
         <route id="call-kie-extract-reports" trace="true">

--- a/src/test/java/org/jboss/xavier/integrations/route/XmlRoutes_RestReportTest.java
+++ b/src/test/java/org/jboss/xavier/integrations/route/XmlRoutes_RestReportTest.java
@@ -21,6 +21,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
@@ -30,7 +32,6 @@ import javax.servlet.http.HttpServletResponse;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.*;
 
 
@@ -305,11 +306,16 @@ public class XmlRoutes_RestReportTest {
         Map<String, Object> variables = new HashMap<>();
         Long one = 1L;
         variables.put("id", one);
-        ResponseEntity<String> response = restTemplate.exchange(camel_context + "report/{id}/workload-inventory/csv" , HttpMethod.GET, null, String.class, variables);
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("whatever", "this header should not be copied");
+        HttpEntity<String> entity = new HttpEntity<>(null, headers);
+        ResponseEntity<String> response = restTemplate.exchange(camel_context + "report/{id}/workload-inventory/csv" , HttpMethod.GET, entity, String.class, variables);
 
         //Then
         verify(workloadInventoryReportService).findByAnalysisId(one);
         Assert.assertTrue(response.getHeaders().get("Content-Type").contains("text/csv"));
+        Assert.assertTrue(response.getHeaders().get("Content-Disposition").contains("attachment;filename=workloadInventory_1.csv"));
+        Assert.assertNull(response.getHeaders().get("whatever"));
         Assert.assertNotNull(response.getBody());
         camelContext.stop();
     }


### PR DESCRIPTION
- moved `bindy` configuration within `marshal` tag since `ref` is deprecated
- replaced ` <setHeader headerName="Content-Type">` with `produces="text/csv"`
- added the `{id}` param value as suffix to the file name to have different file names
- enhanced the test to check:
   - the `Content-Disposition` header has the right value 
   - the `whatever` header won't be copied from the request into the response