### PR TITLE
MIGENG-234

### DIFF
--- a/src/main/java/org/jboss/xavier/analytics/pojo/output/workload/summary/SummaryModel.java
+++ b/src/main/java/org/jboss/xavier/analytics/pojo/output/workload/summary/SummaryModel.java
@@ -36,7 +36,7 @@ import javax.persistence.SqlResultSetMapping;
         query = "select provider, product, version, count(distinct host_name) as hosts, count(distinct cluster) as clusters, sum(cpu_cores)*2 as sockets, count(*) as vms \n" +
                 "from workload_inventory_report_model \n" +
                 "where analysis_id = :analysisId \n" +
-                "group by provider, product, version, host_name \n" +
+                "group by provider, product, version \n" +
                 "order by provider, product, version",
         resultSetMapping = "mappingSummaryModels"
 )

--- a/src/main/java/org/jboss/xavier/analytics/pojo/output/workload/summary/SummaryModel.java
+++ b/src/main/java/org/jboss/xavier/analytics/pojo/output/workload/summary/SummaryModel.java
@@ -33,7 +33,7 @@ import javax.persistence.SqlResultSetMapping;
 
 @NamedNativeQuery(
         name = "SummaryModel.calculateSummaryModels",
-        query = "select provider, product, version, count(distinct host_name) as hosts, count(distinct cluster) as clusters, sum(cpu_cores)*2 as sockets, count(*) as vms \n" +
+        query = "select provider, product, version, count(distinct host_name) as hosts, count(distinct cluster) as clusters, sum(cpu_cores) as sockets, count(*) as vms \n" +
                 "from workload_inventory_report_model \n" +
                 "where analysis_id = :analysisId \n" +
                 "group by provider, product, version \n" +

--- a/src/main/java/org/jboss/xavier/integrations/migrationanalytics/business/VMWorkloadInventoryCalculator.java
+++ b/src/main/java/org/jboss/xavier/integrations/migrationanalytics/business/VMWorkloadInventoryCalculator.java
@@ -31,6 +31,7 @@ public class VMWorkloadInventoryCalculator implements Calculator<Collection<VMWo
     private static final String GUESTOSFULLNAME_FALLBACKPATH = "cloudforms.manifest.{version}.vmworkloadinventory.guestOSFallbackPath";
     private static final String VMNAMEPATH = "cloudforms.manifest.{version}.vmworkloadinventory.vmNamePath";
     private static final String NUMCPUPATH = "cloudforms.manifest.{version}.vmworkloadinventory.numCpuPath";
+    private static final String NUMCORESPERSOCKETPATH = "cloudforms.manifest.{version}.vmworkloadinventory.numCoresPerSocketPath";
     private static final String HASRDMDISKPATH = "cloudforms.manifest.{version}.vmworkloadinventory.hasRDMDiskPath";
     private static final String RAMSIZEINBYTES = "cloudforms.manifest.{version}.vmworkloadinventory.ramSizeInBytesPath";
     private static final String NICSPATH = "cloudforms.manifest.{version}.vmworkloadinventory.nicsPath";
@@ -75,7 +76,7 @@ public class VMWorkloadInventoryCalculator implements Calculator<Collection<VMWo
 
         model.setVmName(readValueFromExpandedEnvVarPath(VMNAMEPATH, vmStructMap ));
         model.setMemory(readValueFromExpandedEnvVarPath(RAMSIZEINBYTES, vmStructMap, Long.class));
-        model.setCpuCores(readValueFromExpandedEnvVarPath(NUMCPUPATH, vmStructMap, Integer.class));
+        model.setCpuCores(((Integer)readValueFromExpandedEnvVarPath(NUMCPUPATH, vmStructMap, Integer.class) / (Integer)readValueFromExpandedEnvVarPath(NUMCORESPERSOCKETPATH, vmStructMap, Integer.class)));
         model.setOsProductName(StringUtils.defaultIfEmpty(readValueFromExpandedEnvVarPath(PRODUCTNAMEPATH, vmStructMap), readValueFromExpandedEnvVarPath(PRODUCTNAME_FALLBACKPATH, vmStructMap )));
         model.setGuestOSFullName(StringUtils.defaultIfEmpty(readValueFromExpandedEnvVarPath(GUESTOSFULLNAMEPATH, vmStructMap ), readValueFromExpandedEnvVarPath(GUESTOSFULLNAME_FALLBACKPATH, vmStructMap )));
         model.setHasRdmDisk(readValueFromExpandedEnvVarPath(HASRDMDISKPATH, vmStructMap));

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -83,6 +83,7 @@ cloudforms.manifest.v1_0_0.vmworkloadinventory.guestOSPath=$.ManageIQ::Providers
 cloudforms.manifest.v1_0_0.vmworkloadinventory.guestOSFallbackPath=$.ManageIQ::Providers::Vmware::InfraManager[*].vms[?(@.id == {id})].hardware.guest_os_full_name
 cloudforms.manifest.v1_0_0.vmworkloadinventory.vmNamePath=$.ManageIQ::Providers::Vmware::InfraManager[*].vms[?(@.id == {id})].name
 cloudforms.manifest.v1_0_0.vmworkloadinventory.numCpuPath=$.ManageIQ::Providers::Vmware::InfraManager[*].vms[?(@.id == {id})].cpu_total_cores
+cloudforms.manifest.v1_0_0.vmworkloadinventory.numCoresPerSocketPath=$.ManageIQ::Providers::Vmware::InfraManager[*].vms[?(@.id == {id})].cpu_cores_per_socket
 cloudforms.manifest.v1_0_0.vmworkloadinventory.hasRDMDiskPath=$.ManageIQ::Providers::Vmware::InfraManager[*].vms[?(@.id == {id})].has_rdm_disk
 cloudforms.manifest.v1_0_0.vmworkloadinventory.ramSizeInBytesPath=$.ManageIQ::Providers::Vmware::InfraManager[*].vms[?(@.id == {id})].ram_size_in_bytes
 cloudforms.manifest.v1_0_0.vmworkloadinventory.nicsPath=$.ManageIQ::Providers::Vmware::InfraManager[*].vms[?(@.id == {id})].hardware.nics.length()
@@ -114,6 +115,8 @@ cloudforms.manifest.v1.vmworkloadinventory.guestOSPath=$.ManageIQ::Providers::Vm
 cloudforms.manifest.v1.vmworkloadinventory.guestOSFallbackPath=$.ManageIQ::Providers::Vmware::InfraManager.hosts[*].vms[?(@.id == {id})].hardware.guest_os_full_name
 cloudforms.manifest.v1.vmworkloadinventory.vmNamePath=$.ManageIQ::Providers::Vmware::InfraManager.hosts[*].vms[?(@.id == {id})].name
 cloudforms.manifest.v1.vmworkloadinventory.numCpuPath=$.ManageIQ::Providers::Vmware::InfraManager.hosts[*].vms[?(@.id == {id})].num_cpu
+# TODO fix this JSONPath
+cloudforms.manifest.v1.vmworkloadinventory.numCoresPerSocketPath=$.ManageIQ::Providers::Vmware::InfraManager.hosts[*].vms[?(@.id == {id})].num_cpu
 cloudforms.manifest.v1.vmworkloadinventory.hasRDMDiskPath=$.ManageIQ::Providers::Vmware::InfraManager.hosts[*].vms[?(@.id == {id})].has_rdm_disk
 cloudforms.manifest.v1.vmworkloadinventory.ramSizeInBytesPath=$.ManageIQ::Providers::Vmware::InfraManager.hosts[*].vms[?(@.id == {id})].ram_size_in_bytes
 cloudforms.manifest.v1.vmworkloadinventory.nicsPath=$.ManageIQ::Providers::Vmware::InfraManager.hosts[*].vms[?(@.id == {id})].hardware.nics.length()

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -66,7 +66,7 @@ camel.component.servlet.mapping.context-path=/api/xavier/*
 
 insights.properties=yearOverYearGrowthRatePercentage,percentageOfHypervisorsMigratedOnYear1,percentageOfHypervisorsMigratedOnYear2,percentageOfHypervisorsMigratedOnYear3, reportName, reportDescription,file
 
-cloudforms.manifest.v1_0_0.hypervisor=$.ManageIQ::Providers::Vmware::InfraManager[*].vms[?(@.cpu_total_cores != null)]
+cloudforms.manifest.v1_0_0.hypervisor=$.ManageIQ::Providers::Vmware::InfraManager[*].hosts[?(@.cpu_total_cores != null)]
 cloudforms.manifest.v1_0_0.hypervisor.cpuTotalCoresPath=cpu_total_cores
 cloudforms.manifest.v1_0_0.hypervisor.cpuCoresPerSocketPath=cpu_cores_per_socket
 cloudforms.manifest.v1_0_0.totalSpacePath=$.ManageIQ::Providers::Vmware::InfraManager[*].vms[*].hardware.disks[?(@.size != null)].size

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -97,7 +97,7 @@ cloudforms.manifest.v1_0_0.vmworkloadinventory.filesContentPathContents=contents
 
 cloudforms.manifest.v1_0_0.vmworkloadinventory.productPath=$.ManageIQ::Providers::Vmware::InfraManager[?(@.vms[?(@.id=={id})])].emstype_description
 cloudforms.manifest.v1_0_0.vmworkloadinventory.versionPath=$.ManageIQ::Providers::Vmware::InfraManager[?(@.vms[?(@.id=={id})])].api_version
-cloudforms.manifest.v1_0_0.vmworkloadinventory.hostNamePath=$.ManageIQ::Providers::Vmware::InfraManager[?(@.vms[?(@.id=={id})])].hostname
+cloudforms.manifest.v1_0_0.vmworkloadinventory.hostNamePath=$.ManageIQ::Providers::Vmware::InfraManager[*].vms[?(@.id == {id})].host.ems_ref
 
 cloudforms.manifest.v1.hypervisor=$.ManageIQ::Providers::Vmware::InfraManager.hosts[?(@.cpu_total_cores != null)]
 cloudforms.manifest.v1.hypervisor.cpuTotalCoresPath=cpu_total_cores

--- a/src/test/java/org/jboss/xavier/integrations/migrationanalytics/business/VMWorkloadInventoryCalculatorTest.java
+++ b/src/test/java/org/jboss/xavier/integrations/migrationanalytics/business/VMWorkloadInventoryCalculatorTest.java
@@ -105,7 +105,7 @@ public class VMWorkloadInventoryCalculatorTest {
         expectedModel.setSystemServicesNames(Arrays.asList("NetworkManager-dispatcher","NetworkManager-wait-online","NetworkManager"));
         expectedModel.setVmDiskFilenames(Arrays.asList("[NFS-Storage] oracle_db_1/", "[NFS-Storage] oracle_db_1/oracle_db.vmdk", "[NFS-Storage] oracle_db_1/"));
         expectedModel.setAnalysisId(analysisId);
-        expectedModel.setHost_name("vcenter.example.com");
+        expectedModel.setHost_name("host-47");
         expectedModel.setVersion("6.7.2");
         expectedModel.setProduct("VMware vCenter");
         HashMap<String, String> files = new HashMap<>();

--- a/src/test/java/org/jboss/xavier/integrations/route/MainRouteBuilder_DirectCalculateVMWorkloadInventoryTest.java
+++ b/src/test/java/org/jboss/xavier/integrations/route/MainRouteBuilder_DirectCalculateVMWorkloadInventoryTest.java
@@ -129,7 +129,7 @@ public class MainRouteBuilder_DirectCalculateVMWorkloadInventoryTest {
         expectedModel.setSystemServicesNames(Arrays.asList("NetworkManager-dispatcher","NetworkManager-wait-online","NetworkManager"));
         expectedModel.setVmDiskFilenames(Arrays.asList("[NFS-Storage] oracle_db_1/", "[NFS-Storage] oracle_db_1/oracle_db.vmdk", "[NFS-Storage] oracle_db_1/"));
         expectedModel.setAnalysisId(analysisId);
-        expectedModel.setHost_name("vcenter.example.com");
+        expectedModel.setHost_name("host-47");
         expectedModel.setVersion("6.7.2");
         expectedModel.setProduct("VMware vCenter");
 

--- a/src/test/java/org/jboss/xavier/integrations/route/WorkloadSummaryReportRoutes_DirectCalculateVMWorkloadInventoryModelTest.java
+++ b/src/test/java/org/jboss/xavier/integrations/route/WorkloadSummaryReportRoutes_DirectCalculateVMWorkloadInventoryModelTest.java
@@ -80,7 +80,7 @@ public class WorkloadSummaryReportRoutes_DirectCalculateVMWorkloadInventoryModel
             workloadInventoryReportModel.setProvider("Provider" + (value % 2));
             workloadInventoryReportModel.setProduct("Product" + (value % 2));
             workloadInventoryReportModel.setVersion("Version" + (value % 2));
-            workloadInventoryReportModel.setHost_name("HostName" + (value % 2));
+            workloadInventoryReportModel.setHost_name("HostName" + (value % 3));
             workloadInventoryReportModel.setCluster("Cluster" + (value % 3));
             workloadInventoryReportModel.setCpuCores(value % 4);
             workloadInventoryReportModel.setComplexity(complexities[value]);
@@ -134,8 +134,8 @@ public class WorkloadSummaryReportRoutes_DirectCalculateVMWorkloadInventoryModel
         Assert.assertEquals("Product1", summaryModelMap.get(2L).getProduct());
         Assert.assertEquals("Version0", summaryModelMap.get(1L).getVersion());
         Assert.assertEquals("Version1", summaryModelMap.get(2L).getVersion());
-        Assert.assertEquals(1, summaryModelMap.get(1L).getHosts(), 0);
-        Assert.assertEquals(1, summaryModelMap.get(2L).getHosts(), 0);
+        Assert.assertEquals(3, summaryModelMap.get(1L).getHosts(), 0);
+        Assert.assertEquals(3, summaryModelMap.get(2L).getHosts(), 0);
         Assert.assertEquals(3, summaryModelMap.get(1L).getClusters(), 0);
         Assert.assertEquals(3, summaryModelMap.get(2L).getClusters(), 0);
         Assert.assertEquals(4L, summaryModelMap.get(1L).getSockets(), 0);

--- a/src/test/java/org/jboss/xavier/integrations/route/WorkloadSummaryReportRoutes_DirectCalculateVMWorkloadInventoryModelTest.java
+++ b/src/test/java/org/jboss/xavier/integrations/route/WorkloadSummaryReportRoutes_DirectCalculateVMWorkloadInventoryModelTest.java
@@ -138,8 +138,8 @@ public class WorkloadSummaryReportRoutes_DirectCalculateVMWorkloadInventoryModel
         Assert.assertEquals(3, summaryModelMap.get(2L).getHosts(), 0);
         Assert.assertEquals(3, summaryModelMap.get(1L).getClusters(), 0);
         Assert.assertEquals(3, summaryModelMap.get(2L).getClusters(), 0);
-        Assert.assertEquals(4L, summaryModelMap.get(1L).getSockets(), 0);
-        Assert.assertEquals(10L, summaryModelMap.get(2L).getSockets(), 0);
+        Assert.assertEquals(2L, summaryModelMap.get(1L).getSockets(), 0);
+        Assert.assertEquals(5L, summaryModelMap.get(2L).getSockets(), 0);
         Assert.assertEquals(3, summaryModelMap.get(1L).getVms(), 0);
         Assert.assertEquals(3, summaryModelMap.get(2L).getVms(), 0);
 


### PR DESCRIPTION
- Changed `Sockets` field formula (removed `* 2` because it seemed to be wrong with the latest payload)
- removed `host_name` from `group by` otherwise we would have multiple lines in the Summary table and the `count(distinct host_name)` would have been always `1`
- added `NUMCORESPERSOCKETPATH` field with JSONPath
- changed the `hypervisor` path for the ICS to work with `hosts` array
- changed the JSONPath to get the host name for each VM 