### PR TITLE
Migeng 324: Add RBAC checkings to all endpoints

### DIFF
--- a/src/main/java/org/jboss/xavier/integrations/rbac/ResourceTypes.java
+++ b/src/main/java/org/jboss/xavier/integrations/rbac/ResourceTypes.java
@@ -1,6 +1,5 @@
 package org.jboss.xavier.integrations.rbac;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -11,13 +10,8 @@ public class ResourceTypes {
     public static final Map<String, List<String>> RESOURCE_TYPES = new HashMap<>();
 
     static {
+        RESOURCE_TYPES.put("api", Collections.singletonList("read"));
         RESOURCE_TYPES.put("user", Collections.singletonList("read"));
-        RESOURCE_TYPES.put("analysis", Arrays.asList("read", "write"));
-        RESOURCE_TYPES.put("payload", Arrays.asList("read", "write"));
-        RESOURCE_TYPES.put("report.initial-saving-estimation", Collections.singletonList("read"));
-        RESOURCE_TYPES.put("report.workload-summary", Collections.singletonList("read"));
-        RESOURCE_TYPES.put("report.workload-inventory", Collections.singletonList("read"));
-        RESOURCE_TYPES.put("mappings", Collections.singletonList("read"));
     }
 
 }

--- a/src/main/java/org/jboss/xavier/integrations/route/MainRouteBuilder.java
+++ b/src/main/java/org/jboss/xavier/integrations/route/MainRouteBuilder.java
@@ -22,6 +22,7 @@ import org.jboss.xavier.analytics.pojo.PayloadDownloadLinkModel;
 import org.jboss.xavier.analytics.pojo.input.UploadFormInputDataModel;
 import org.jboss.xavier.analytics.pojo.output.AnalysisModel;
 import org.jboss.xavier.integrations.jpa.service.UserService;
+import org.jboss.xavier.integrations.rbac.RBACRouteBuilder;
 import org.jboss.xavier.integrations.route.dataformat.CustomizedMultipartDataFormat;
 import org.jboss.xavier.integrations.route.model.notification.FilePersistedNotification;
 import org.springframework.beans.factory.annotation.Value;
@@ -85,6 +86,12 @@ public class MainRouteBuilder extends RouteBuilderExceptionHandler {
         from("rest:post:/upload?consumes=multipart/form-data")
                 .routeId("rest-upload")
                 .to("direct:check-authenticated-request")
+                .to("direct:fetch-and-process-rbac-user-access")
+                // RBAC check start: check min user permissions
+                .setHeader(RBACRouteBuilder.RBAC_ENDPOINT_RESOURCE_NAME, constant("api"))
+                .setHeader(RBACRouteBuilder.RBAC_ENDPOINT_RESOURCE_PERMISSION, constant("read"))
+                .to("direct:check-rbac-permissions")
+                // RBAC check end
                 .to("direct:upload");
 
         from("direct:upload").routeId("direct-upload")

--- a/src/main/resources/spring/camel-context.xml
+++ b/src/main/resources/spring/camel-context.xml
@@ -52,6 +52,11 @@
         <interceptFrom id="interceptor-username" uri="rest:*">
             <to uri="direct:check-authenticated-request" />
             <to uri="direct:fetch-and-process-rbac-user-access" />
+            <!-- RBAC check start: check min user permissions-->
+            <setHeader headerName="${type:org.jboss.xavier.integrations.rbac.RBACRouteBuilder.RBAC_ENDPOINT_RESOURCE_NAME}"><constant>api</constant></setHeader>
+            <setHeader headerName="${type:org.jboss.xavier.integrations.rbac.RBACRouteBuilder.RBAC_ENDPOINT_RESOURCE_PERMISSION}"><constant>read</constant></setHeader>
+            <to uri="direct:check-rbac-permissions" />
+            <!-- RBAC check end-->
             <when>
                 <simple>${header.CamelServletContextPath} contains '/administration/'</simple>
                 <to uri="direct:check-authorized-request" />
@@ -301,10 +306,11 @@
             <get uri="/" outType="org.jboss.xavier.integrations.route.model.user.User">
                 <description>Get session user info</description>
                 <route id="get-user-info">
+                    <!-- RBAC check start-->
                     <setHeader headerName="${type:org.jboss.xavier.integrations.rbac.RBACRouteBuilder.RBAC_ENDPOINT_RESOURCE_NAME}"><constant>user</constant></setHeader>
                     <setHeader headerName="${type:org.jboss.xavier.integrations.rbac.RBACRouteBuilder.RBAC_ENDPOINT_RESOURCE_PERMISSION}"><constant>read</constant></setHeader>
                     <to uri="direct:check-rbac-permissions" />
-
+                    <!-- RBAC check end-->
                     <bean ref="userService" method="findUser(${header.${type:org.jboss.xavier.integrations.route.RouteBuilderExceptionHandler.USERNAME}})" />
                 </route>
             </get>

--- a/src/test/java/org/jboss/xavier/integrations/rbac/RBACInterceptorTest.java
+++ b/src/test/java/org/jboss/xavier/integrations/rbac/RBACInterceptorTest.java
@@ -1,0 +1,132 @@
+package org.jboss.xavier.integrations.rbac;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.camel.Exchange;
+import org.apache.camel.Route;
+import org.apache.camel.builder.AdviceWithRouteBuilder;
+import org.apache.camel.component.rest.RestEndpoint;
+import org.jboss.xavier.Application;
+import org.jboss.xavier.integrations.route.XavierCamelTest;
+import org.jboss.xavier.integrations.util.TestUtil;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(classes = {Application.class}, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class RBACInterceptorTest extends XavierCamelTest {
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Value("${camel.component.servlet.mapping.context-path}")
+    String camel_context;
+
+    @Before
+    public void setup() {
+        camel_context = camel_context.substring(0, camel_context.indexOf("*"));
+    }
+
+    private String buildJSONStringRBACResponse(String permission) {
+        RbacResponse rbacResponse = new RbacResponse(
+                new RbacResponse.Meta(1, 10, 0),
+                new RbacResponse.Links(null, null, null, null),
+                Collections.singletonList(
+                        new Acl(permission, Collections.emptyList()))
+        );
+        try {
+            return new ObjectMapper().writeValueAsString(rbacResponse);
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+            throw new IllegalStateException(e);
+        }
+    }
+
+    /***
+     * The Min user permissions is: 'api:read'. If user has not at least min permissions then Forbidden
+     * */
+    @Test
+    public void xmlRouteBuilder_RestEndpoints_NoMinUserPermissions_ShouldReturnForbidden() throws Exception {
+        //Given
+        camelContext.getRouteDefinition("fetch-rbac-user-access").adviceWith(camelContext, new AdviceWithRouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                weaveById("fetch-rbac-user-access-endpoint").replace()
+                        .setHeader(Exchange.HTTP_RESPONSE_CODE, simple("200"))
+                        .setBody(exchange -> buildJSONStringRBACResponse("migration-analytics:someResource:write"));
+            }
+        });
+
+
+        final AtomicInteger restEndpointsTested = new AtomicInteger(0);
+
+        //When
+        camelContext.start();
+        TestUtil.startUsernameRoutes(camelContext);
+
+        Supplier<Stream<Route>> streamRestRouteSupplier = () -> camelContext.getRoutes().stream()
+                .filter(route -> route.getEndpoint() instanceof RestEndpoint);
+
+        long expectedRestEndpointsTested = streamRestRouteSupplier.get().count();
+        streamRestRouteSupplier.get()
+                .forEach(route -> {
+                    try {
+                        camelContext.startRoute(route.getId());
+
+                        // RH Identity
+                        HttpHeaders headers = new HttpHeaders();
+                        headers.set(TestUtil.HEADER_RH_IDENTITY, TestUtil.getBase64RHIdentity());
+                        HttpEntity<String> entity = new HttpEntity<>(null, headers);
+
+                        Map<String, Object> variables = new HashMap<>();
+                        Long one = 1L;
+                        variables.put("id", one);
+
+                        RestEndpoint restEndpoint = (RestEndpoint) route.getEndpoint();
+                        String url = camel_context + restEndpoint.getPath();
+                        if (restEndpoint.getUriTemplate() != null) url += restEndpoint.getUriTemplate();
+
+                        // Call endpoint
+                        ResponseEntity<String> result = restTemplate.exchange(
+                                url,
+                                HttpMethod.resolve(restEndpoint.getMethod().toUpperCase()),
+                                entity,
+                                String.class,
+                                variables);
+
+                        //Then
+                        assertThat(result).isNotNull();
+                        assertThat(result.getStatusCodeValue()).isEqualByComparingTo(403);
+                        assertThat(result.getBody()).isEqualTo("Forbidden");
+
+                        restEndpointsTested.incrementAndGet();
+
+                        camelContext.stopRoute(route.getId());
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                });
+
+        assertThat(expectedRestEndpointsTested).isGreaterThanOrEqualTo(1);
+        assertThat(restEndpointsTested.get()).isEqualTo(expectedRestEndpointsTested);
+
+        camelContext.stop();
+    }
+
+}


### PR DESCRIPTION
- Added a general resource and permission `migration-analytics:api:read` which every user must have to have access to any endpoint. This is for forcing the check of permissions on every endpoint
- Add a permissions check just after the camel filter gets the processed data from RBAC.
- Added a test for checking all endpoints require permissions checks